### PR TITLE
fix: use node:assert instead of vitest expect in storage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/db-utils",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Use node:assert in place of vitest expect so there is no dependency on any exported code on vitest