### PR TITLE
feat: support 'auto' for simple mapped columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apimda/db-utils",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "exports": {
     ".": {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -44,7 +44,7 @@ export type ColumnMarker = typeof id | typeof createdAt | typeof updatedAt;
 export type SimpleColumnDef = typeof auto | ColumnMarker | string | [string, ColumnMarker];
 
 export type MappedColumnDef<T> = {
-  column: string | SqlColumn;
+  column: typeof auto | string | SqlColumn;
   marker?: ColumnMarker;
   mapper: SimplePropertyMapper<T>;
 };
@@ -80,8 +80,12 @@ export function mapping<T>(tableName: string, defaults: MapperDefaults, mappingD
     return new SimpleColumnMapping(new Column(columnName, marker), propName, defaults.properties);
   }
 
-  function fromMappedDef(def: MappedColumnDef<any>, propName: string) {
-    return new SimpleColumnMapping(new Column(def.column, def.marker), propName, def.mapper);
+  function fromMappedDef(def: MappedColumnDef<any>, componentPath: string[], propName: string) {
+    const col =
+      def.column === auto
+        ? defaults.columns.buildPrefix(componentPath) + defaults.columns.propertyNameToColumnName(propName!)
+        : def.column;
+    return new SimpleColumnMapping(new Column(col, def.marker), propName, def.mapper);
   }
 
   function fromMultiMappedDef(def: MultiMappedColumnDef<any>, propName: string) {
@@ -100,7 +104,7 @@ export function mapping<T>(tableName: string, defaults: MapperDefaults, mappingD
     ) {
       return fromSimpleDef(def as SimpleColumnDef, componentPath, propName!);
     } else if ('column' in def) {
-      return fromMappedDef(def as MappedColumnDef<any>, propName!);
+      return fromMappedDef(def as MappedColumnDef<any>, componentPath, propName!);
     } else if ('columns' in def) {
       return fromMultiMappedDef(def as MultiMappedColumnDef<any>, propName!);
     } else {

--- a/src/test/dao.test.ts
+++ b/src/test/dao.test.ts
@@ -24,6 +24,7 @@ class TestSchemaManager implements SchemaManager {
       money_amount        bigint                                    NOT NULL,
       money_currency      text                                      NOT NULL, 
       sql_test            text,
+      mapped_auto         bigint                                    NOT NULL,
       created             timestamptz   DEFAULT NOW()               NOT NULL,
       updated             timestamptz   DEFAULT NOW()               NOT NULL,
 
@@ -49,6 +50,7 @@ interface TestObj {
   };
   money: Money;
   sqlTest?: string;
+  mappedAuto: bigint;
   created?: Date;
   updated?: Date;
 }
@@ -77,6 +79,13 @@ const testMapping = mapping<TestObj>('test_obj', mapperDefaults, {
     mapper: {
       fromDb: rowVal => (rowVal ? (rowVal as string) : undefined),
       toDb: (value, sql) => (value ? sql`LOWER(${value})` : null)
+    }
+  },
+  mappedAuto: {
+    column: auto,
+    mapper: {
+      fromDb: rowVal => BigInt(rowVal as string),
+      toDb: value => value.toString()
     }
   },
   created: createdAt,
@@ -118,9 +127,10 @@ describe(' DAO Tests', () => {
         objName: 'some name',
         isAdmin: true,
         myComp: { nestedOne: 1, nestedTwo: 2 },
-        money: new Money(9007199254740991n, 'USD')
+        money: new Money(9007199254740991n, 'USD'),
+        mappedAuto: 100n
       }),
-      entity => ({ ...entity, objName: 'new name', isAdmin: false, sqlTest: 'ALL UPPER CASE' })
+      entity => ({ ...entity, objName: 'new name', isAdmin: false, sqlTest: 'ALL UPPER CASE', mappedAuto: 200n })
     );
   });
 });


### PR DESCRIPTION
Allows using 'auto' for column in simple mapping, e.g. from test case -
```
mappedAuto: {
    column: auto,
    mapper: {
      fromDb: rowVal => BigInt(rowVal as string),
      toDb: value => value.toString()
    }
  },
```